### PR TITLE
Fix navigate to DbList page when client is already connected

### DIFF
--- a/src/renderer/pages/Conns.vue
+++ b/src/renderer/pages/Conns.vue
@@ -97,6 +97,13 @@ export default {
         console.log('dblist')
         this.$router.push({name: 'DbList', params: { id: connection._id }})
       })
+
+      // navigate if client is already connected
+      if (client.connected) {
+        this.setCurConnectionName(connection.name)
+        console.log('connected')
+        this.$router.push({name: 'DbList', params: { id: connection._id }})
+      }
     },
     onSetting (index) {
       this.connectionIndex = index


### PR DESCRIPTION
If client is cached, second time go to DbList page will failed. Because client will not trigger connect event any more.